### PR TITLE
Conway's Game of Life Basic Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ This is an implementation of [Conway's Game of Life](https://en.wikipedia.org/wi
 written in Rust with the [macroquad](https://macroquad.rs) crate.
 
 ## Running
+
 * Clone the repository `git clone git@github.com:dsocolobsky/conways.git`
 * Run `cargo run`
 
 ## Implemented Features
+
 * Barebones project structure and window display.
+* Conway's Game of Life in a 32x32 grid.

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,0 +1,101 @@
+pub const GRID_WIDTH: usize = 32;
+pub const GRID_HEIGHT: usize = 32;
+pub const CELL_SIZE: f32 = 30.0;
+
+#[derive(Copy, Clone, PartialEq, Default)]
+pub enum CellState {
+    #[default]
+    Dead,
+    Alive,
+}
+
+pub type Grid = [[CellState; GRID_WIDTH]; GRID_HEIGHT];
+
+fn valid_coordinate(x: usize, y: usize) -> bool {
+    x < GRID_WIDTH && y < GRID_HEIGHT
+}
+
+pub fn get_cell_state(grid: &Grid, x: usize, y: usize) -> Option<CellState> {
+    if valid_coordinate(x, y) {
+        Some(grid[x][y])
+    } else {
+        None
+    }
+}
+
+fn neighbours(grid: &Grid, x: usize, y: usize) -> Vec<Option<CellState>> {
+    let mut vec: Vec<Option<CellState>> = vec![];
+    if x > 0 {
+        vec.push(get_cell_state(&grid, x - 1, y));
+        if y > 0 {
+            vec.push(get_cell_state(&grid, x - 1, y - 1));
+        }
+        if y < 255 {
+            vec.push(get_cell_state(&grid, x - 1, y + 1));
+        }
+    }
+    if x < 255 {
+        vec.push(get_cell_state(&grid, x + 1, y));
+        if y > 0 {
+            vec.push(get_cell_state(&grid, x + 1, y - 1));
+        }
+        if y < 255 {
+            vec.push(get_cell_state(&grid, x + 1, y + 1));
+        }
+    }
+    if y > 0 {
+        vec.push(get_cell_state(&grid, x, y - 1));
+    }
+    if y < 255 {
+        vec.push(get_cell_state(&grid, x, y + 1));
+    }
+    vec
+}
+
+fn alive_neighbours(grid: &Grid, x: usize, y: usize) -> usize {
+    neighbours(grid, x, y)
+        .into_iter()
+        .flatten()
+        .filter(|state| *state == CellState::Alive)
+        .count()
+}
+
+fn next_state_for_cell(grid: &Grid, x: usize, y: usize) -> CellState {
+    let Some(cell_state) = get_cell_state(grid, x, y) else {
+        panic!("Invalid coordinate");
+    };
+    let neighbours = alive_neighbours(grid, x, y);
+    if cell_state == CellState::Alive {
+        if neighbours < 2 || neighbours > 3 {
+            CellState::Dead
+        } else {
+            CellState::Alive
+        }
+    } else {
+        if neighbours == 3 {
+            CellState::Alive
+        } else {
+            CellState::Dead
+        }
+    }
+}
+
+pub fn next_state_for_grid(grid: &Grid) -> Grid {
+    let mut new_grid: Grid = [[CellState::Dead; GRID_WIDTH]; GRID_HEIGHT];
+
+    for (i, row) in grid.iter().enumerate() {
+        for (j, _) in row.iter().enumerate() {
+            new_grid[i][j] = next_state_for_cell(grid, i, j);
+        }
+    }
+
+    new_grid
+}
+
+pub fn create_initial_grid(alive: Vec<(usize, usize)>) -> Grid {
+    let mut new_grid: Grid = [[CellState::Dead; GRID_WIDTH]; GRID_HEIGHT];
+    for (i, j) in alive {
+        new_grid[i][j] = CellState::Alive;
+    }
+    new_grid
+}

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -2,7 +2,7 @@ pub const GRID_WIDTH: usize = 32;
 pub const GRID_HEIGHT: usize = 32;
 pub const CELL_SIZE: f32 = 30.0;
 
-#[derive(Copy, Clone, PartialEq, Default)]
+#[derive(Copy, Clone, PartialEq, Default, Debug)]
 pub enum CellState {
     #[default]
     Dead,
@@ -20,6 +20,13 @@ pub fn get_cell_state(grid: &Grid, x: usize, y: usize) -> Option<CellState> {
         Some(grid[x][y])
     } else {
         None
+    }
+}
+
+pub fn cell_is_alive(grid: &Grid, x: usize, y: usize) -> bool {
+    match get_cell_state(grid, x, y) {
+        Some(state) => state == CellState::Alive,
+        _ => false,
     }
 }
 
@@ -61,11 +68,9 @@ fn alive_neighbours(grid: &Grid, x: usize, y: usize) -> usize {
 }
 
 fn next_state_for_cell(grid: &Grid, x: usize, y: usize) -> CellState {
-    let Some(cell_state) = get_cell_state(grid, x, y) else {
-        panic!("Invalid coordinate");
-    };
+    let currently_alive = cell_is_alive(grid, x, y);
     let neighbours = alive_neighbours(grid, x, y);
-    if cell_state == CellState::Alive {
+    if currently_alive {
         if neighbours < 2 || neighbours > 3 {
             CellState::Dead
         } else {
@@ -98,4 +103,71 @@ pub fn create_initial_grid(alive: Vec<(usize, usize)>) -> Grid {
         new_grid[i][j] = CellState::Alive;
     }
     new_grid
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::grid::{cell_is_alive, create_initial_grid, next_state_for_grid, CellState};
+
+    #[test]
+    fn create_grid() {
+        let grid = create_initial_grid(vec![(5, 5)]);
+        for (i, &row) in grid.iter().enumerate() {
+            for (j, &cell) in row.iter().enumerate() {
+                if i == 5 && j == 5 {
+                    assert_eq!(cell, CellState::Alive)
+                } else {
+                    assert_eq!(cell, CellState::Dead)
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn cell_dies_of_underpopulation() {
+        let grid = create_initial_grid(vec![(5, 5)]);
+        assert!(cell_is_alive(&grid, 5, 5));
+        let grid = next_state_for_grid(&grid);
+        assert!(!cell_is_alive(&grid, 5, 5));
+    }
+
+    #[test]
+    fn cell_dies_of_overpopulation() {
+        let grid = create_initial_grid(vec![(5, 5), (5, 6), (5, 4), (4, 5), (6, 6)]);
+        assert!(cell_is_alive(&grid, 5, 5));
+        let grid = next_state_for_grid(&grid);
+        assert!(!cell_is_alive(&grid, 5, 5));
+    }
+
+    #[test]
+    fn cell_survives() {
+        let grid = create_initial_grid(vec![(5, 5), (5, 6), (5, 4)]);
+        assert!(cell_is_alive(&grid, 5, 5));
+        let grid = next_state_for_grid(&grid);
+        assert!(cell_is_alive(&grid, 5, 5));
+    }
+
+    #[test]
+    fn blinker_pattern() {
+        let grid = create_initial_grid(vec![(5, 5), (5, 6), (5, 7)]);
+        assert!(cell_is_alive(&grid, 5, 5));
+        assert!(cell_is_alive(&grid, 5, 6));
+        assert!(cell_is_alive(&grid, 5, 7));
+
+        let grid = next_state_for_grid(&grid);
+        assert!(cell_is_alive(&grid, 4, 6));
+        assert!(cell_is_alive(&grid, 5, 6));
+        assert!(cell_is_alive(&grid, 6, 6));
+
+        assert!(!cell_is_alive(&grid, 5, 5));
+        assert!(!cell_is_alive(&grid, 5, 7));
+
+        let grid = next_state_for_grid(&grid);
+        assert!(cell_is_alive(&grid, 5, 5));
+        assert!(cell_is_alive(&grid, 5, 6));
+        assert!(cell_is_alive(&grid, 5, 7));
+
+        assert!(!cell_is_alive(&grid, 4, 6));
+        assert!(!cell_is_alive(&grid, 6, 6));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,17 +50,33 @@ fn set_dead(grid: &mut Grid, x: usize, y: usize) {
     set_state(grid, x, y, CellState::Dead);
 }
 
-fn neighbours(grid: &Grid, x: usize, y: usize) -> [Option<CellState>; 8] {
-    [
-        get_state(&grid, x, y - 1),
-        get_state(&grid, x, y + 1),
-        get_state(&grid, x - 1, y),
-        get_state(&grid, x + 1, y),
-        get_state(&grid, x - 1, y - 1),
-        get_state(&grid, x - 1, y + 1),
-        get_state(&grid, x + 1, y - 1),
-        get_state(&grid, x + 1, y + 1),
-    ]
+fn neighbours(grid: &Grid, x: usize, y: usize) -> Vec<Option<CellState>> {
+    let mut vec: Vec<Option<CellState>> = vec![];
+    if x > 0 {
+        vec.push(get_state(&grid, x - 1, y));
+        if y > 0 {
+            vec.push(get_state(&grid, x - 1, y - 1));
+        }
+        if y < 255 {
+            vec.push(get_state(&grid, x - 1, y + 1));
+        }
+    }
+    if x < 255 {
+        vec.push(get_state(&grid, x + 1, y));
+        if y > 0 {
+            vec.push(get_state(&grid, x + 1, y - 1));
+        }
+        if y < 255 {
+            vec.push(get_state(&grid, x + 1, y + 1));
+        }
+    }
+    if y > 0 {
+        vec.push(get_state(&grid, x, y - 1));
+    }
+    if y < 255 {
+        vec.push(get_state(&grid, x, y + 1));
+    }
+    vec
 }
 
 fn alive_neighbours(grid: &Grid, x: usize, y: usize) -> usize {
@@ -113,7 +129,7 @@ fn create_initial_grid(alive: Vec<(usize, usize)>) -> Grid {
 
 #[macroquad::main(window_conf)]
 async fn main() {
-    let mut grid: Grid = create_initial_grid(vec![(4, 4), (10, 10)]);
+    let mut grid: Grid = create_initial_grid(vec![(5, 5), (6, 6), (7, 4), (7, 5), (7, 6)]);
 
     loop {
         clear_background(DARKGRAY);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,11 @@ const GRID_WIDTH: usize = 32;
 const GRID_HEIGHT: usize = 32;
 const CELL_SIZE: f32 = 30.0;
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Default)]
 enum CellState {
-    Alive,
+    #[default]
     Dead,
+    Alive,
 }
 
 fn window_conf() -> Conf {
@@ -23,14 +24,15 @@ fn window_conf() -> Conf {
 type Grid = [[CellState; GRID_WIDTH]; GRID_HEIGHT];
 
 fn valid_coordinate(x: usize, y: usize) -> bool {
-    x >= 0 && x < GRID_WIDTH && y >= 0 && y < GRID_HEIGHT
+    x < GRID_WIDTH && y < GRID_HEIGHT
 }
 
-fn get_state(grid: &Grid, x: usize, y: usize) -> CellState {
-    if !valid_coordinate(x, y) {
-        panic!("Invalid coordinate");
+fn get_state(grid: &Grid, x: usize, y: usize) -> Option<CellState> {
+    if valid_coordinate(x, y) {
+        Some(grid[x][y])
+    } else {
+        None
     }
-    grid[x][y]
 }
 
 fn set_state(grid: &mut Grid, x: usize, y: usize, state: CellState) {
@@ -48,18 +50,82 @@ fn set_dead(grid: &mut Grid, x: usize, y: usize) {
     set_state(grid, x, y, CellState::Dead);
 }
 
+fn neighbours(grid: &Grid, x: usize, y: usize) -> [Option<CellState>; 8] {
+    [
+        get_state(&grid, x, y - 1),
+        get_state(&grid, x, y + 1),
+        get_state(&grid, x - 1, y),
+        get_state(&grid, x + 1, y),
+        get_state(&grid, x - 1, y - 1),
+        get_state(&grid, x - 1, y + 1),
+        get_state(&grid, x + 1, y - 1),
+        get_state(&grid, x + 1, y + 1),
+    ]
+}
+
+fn alive_neighbours(grid: &Grid, x: usize, y: usize) -> usize {
+    neighbours(grid, x, y)
+        .into_iter()
+        .flatten()
+        .filter(|state| *state == CellState::Alive)
+        .count()
+}
+
+fn next_state_for_cell(grid: &Grid, x: usize, y: usize) -> CellState {
+    let Some(cell_state) = get_state(grid, x, y) else {
+        panic!("Invalid coordinate");
+    };
+    let neighbours = alive_neighbours(grid, x, y);
+    if cell_state == CellState::Alive {
+        if neighbours < 2 || neighbours > 3 {
+            CellState::Dead
+        } else {
+            CellState::Alive
+        }
+    } else {
+        if neighbours == 3 {
+            CellState::Alive
+        } else {
+            CellState::Dead
+        }
+    }
+}
+
+fn next_state_for_grid(grid: &Grid) -> Grid {
+    let mut new_grid: Grid = [[CellState::Dead; GRID_WIDTH]; GRID_HEIGHT];
+
+    for i in 0..GRID_WIDTH {
+        for j in 0..GRID_HEIGHT {
+            new_grid[i][j] = next_state_for_cell(grid, i, j);
+        }
+    }
+
+    new_grid
+}
+
+fn create_initial_grid(alive: Vec<(usize, usize)>) -> Grid {
+    let mut new_grid: Grid = [[CellState::Dead; GRID_WIDTH]; GRID_HEIGHT];
+    for (i, j) in alive {
+        set_alive(&mut new_grid, i, j);
+    }
+    new_grid
+}
+
 #[macroquad::main(window_conf)]
 async fn main() {
-    let mut grid: Grid = [[CellState::Dead; GRID_WIDTH]; GRID_HEIGHT];
-    set_alive(&mut grid, 4, 4);
+    let mut grid: Grid = create_initial_grid(vec![(4, 4), (10, 10)]);
 
     loop {
         clear_background(DARKGRAY);
 
-        for i in (0..GRID_WIDTH) {
-            for j in (0..GRID_HEIGHT) {
-                let state = get_state(&grid, i, j);
-                let color = if (state == CellState::Alive) {
+        if is_key_released(KeyCode::Space) {
+            grid = next_state_for_grid(&grid);
+        }
+
+        for i in 0..GRID_WIDTH {
+            for j in 0..GRID_HEIGHT {
+                let state = get_state(&grid, i, j).unwrap_or_default();
+                let color = if state == CellState::Alive {
                     YELLOW
                 } else {
                     LIGHTGRAY

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,12 +129,15 @@ fn create_initial_grid(alive: Vec<(usize, usize)>) -> Grid {
 
 #[macroquad::main(window_conf)]
 async fn main() {
+    let mut last_update = get_time();
+    let speed = 0.3;
     let mut grid: Grid = create_initial_grid(vec![(5, 5), (6, 6), (7, 4), (7, 5), (7, 6)]);
 
     loop {
         clear_background(DARKGRAY);
 
-        if is_key_released(KeyCode::Space) {
+        if get_time() - last_update > speed {
+            last_update = get_time();
             grid = next_state_for_grid(&grid);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,7 @@
+mod grid;
+
+use crate::grid::{CellState, Grid};
 use macroquad::prelude::*;
-
-const GRID_WIDTH: usize = 32;
-const GRID_HEIGHT: usize = 32;
-const CELL_SIZE: f32 = 30.0;
-
-#[derive(Copy, Clone, PartialEq, Default)]
-enum CellState {
-    #[default]
-    Dead,
-    Alive,
-}
 
 fn window_conf() -> Conf {
     Conf {
@@ -21,139 +13,42 @@ fn window_conf() -> Conf {
     }
 }
 
-type Grid = [[CellState; GRID_WIDTH]; GRID_HEIGHT];
-
-fn valid_coordinate(x: usize, y: usize) -> bool {
-    x < GRID_WIDTH && y < GRID_HEIGHT
-}
-
-fn get_state(grid: &Grid, x: usize, y: usize) -> Option<CellState> {
-    if valid_coordinate(x, y) {
-        Some(grid[x][y])
-    } else {
-        None
-    }
-}
-
-fn set_state(grid: &mut Grid, x: usize, y: usize, state: CellState) {
-    if !valid_coordinate(x, y) {
-        panic!("Invalid coordinate");
-    }
-    grid[x][y] = state;
-}
-
-fn set_alive(grid: &mut Grid, x: usize, y: usize) {
-    set_state(grid, x, y, CellState::Alive);
-}
-
-fn set_dead(grid: &mut Grid, x: usize, y: usize) {
-    set_state(grid, x, y, CellState::Dead);
-}
-
-fn neighbours(grid: &Grid, x: usize, y: usize) -> Vec<Option<CellState>> {
-    let mut vec: Vec<Option<CellState>> = vec![];
-    if x > 0 {
-        vec.push(get_state(&grid, x - 1, y));
-        if y > 0 {
-            vec.push(get_state(&grid, x - 1, y - 1));
-        }
-        if y < 255 {
-            vec.push(get_state(&grid, x - 1, y + 1));
-        }
-    }
-    if x < 255 {
-        vec.push(get_state(&grid, x + 1, y));
-        if y > 0 {
-            vec.push(get_state(&grid, x + 1, y - 1));
-        }
-        if y < 255 {
-            vec.push(get_state(&grid, x + 1, y + 1));
-        }
-    }
-    if y > 0 {
-        vec.push(get_state(&grid, x, y - 1));
-    }
-    if y < 255 {
-        vec.push(get_state(&grid, x, y + 1));
-    }
-    vec
-}
-
-fn alive_neighbours(grid: &Grid, x: usize, y: usize) -> usize {
-    neighbours(grid, x, y)
-        .into_iter()
-        .flatten()
-        .filter(|state| *state == CellState::Alive)
-        .count()
-}
-
-fn next_state_for_cell(grid: &Grid, x: usize, y: usize) -> CellState {
-    let Some(cell_state) = get_state(grid, x, y) else {
-        panic!("Invalid coordinate");
-    };
-    let neighbours = alive_neighbours(grid, x, y);
-    if cell_state == CellState::Alive {
-        if neighbours < 2 || neighbours > 3 {
-            CellState::Dead
-        } else {
-            CellState::Alive
-        }
-    } else {
-        if neighbours == 3 {
-            CellState::Alive
-        } else {
-            CellState::Dead
-        }
-    }
-}
-
-fn next_state_for_grid(grid: &Grid) -> Grid {
-    let mut new_grid: Grid = [[CellState::Dead; GRID_WIDTH]; GRID_HEIGHT];
-
-    for i in 0..GRID_WIDTH {
-        for j in 0..GRID_HEIGHT {
-            new_grid[i][j] = next_state_for_cell(grid, i, j);
-        }
-    }
-
-    new_grid
-}
-
-fn create_initial_grid(alive: Vec<(usize, usize)>) -> Grid {
-    let mut new_grid: Grid = [[CellState::Dead; GRID_WIDTH]; GRID_HEIGHT];
-    for (i, j) in alive {
-        set_alive(&mut new_grid, i, j);
-    }
-    new_grid
-}
-
 #[macroquad::main(window_conf)]
 async fn main() {
     let mut last_update = get_time();
     let speed = 0.3;
-    let mut grid: Grid = create_initial_grid(vec![(5, 5), (6, 6), (7, 4), (7, 5), (7, 6)]);
+    let mut grid: Grid = grid::create_initial_grid(vec![
+        (5, 5),
+        (6, 6),
+        (7, 4),
+        (7, 5),
+        (7, 6), // Glider
+        (12, 12),
+        (13, 12),
+        (14, 12), // Stick
+    ]);
 
     loop {
         clear_background(DARKGRAY);
 
         if get_time() - last_update > speed {
             last_update = get_time();
-            grid = next_state_for_grid(&grid);
+            grid = grid::next_state_for_grid(&grid);
         }
 
-        for i in 0..GRID_WIDTH {
-            for j in 0..GRID_HEIGHT {
-                let state = get_state(&grid, i, j).unwrap_or_default();
+        for (i, row) in grid.iter().enumerate() {
+            for (j, _) in row.iter().enumerate() {
+                let state = grid::get_cell_state(&grid, i, j).unwrap_or_default();
                 let color = if state == CellState::Alive {
                     YELLOW
                 } else {
                     LIGHTGRAY
                 };
                 draw_rectangle(
-                    (GRID_WIDTH * i) as f32,
-                    (GRID_HEIGHT * j) as f32,
-                    CELL_SIZE,
-                    CELL_SIZE,
+                    (grid::GRID_WIDTH * i) as f32,
+                    (grid::GRID_HEIGHT * j) as f32,
+                    grid::CELL_SIZE,
+                    grid::CELL_SIZE,
                     color,
                 );
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,78 @@
 use macroquad::prelude::*;
 
-#[macroquad::main("Conways")]
+const GRID_WIDTH: usize = 32;
+const GRID_HEIGHT: usize = 32;
+const CELL_SIZE: f32 = 30.0;
+
+#[derive(Copy, Clone, PartialEq)]
+enum CellState {
+    Alive,
+    Dead,
+}
+
+fn window_conf() -> Conf {
+    Conf {
+        window_title: String::from("Conways"),
+        window_width: 1024,
+        window_height: 1024,
+        fullscreen: false,
+        ..Default::default()
+    }
+}
+
+type Grid = [[CellState; GRID_WIDTH]; GRID_HEIGHT];
+
+fn valid_coordinate(x: usize, y: usize) -> bool {
+    x >= 0 && x < GRID_WIDTH && y >= 0 && y < GRID_HEIGHT
+}
+
+fn get_state(grid: &Grid, x: usize, y: usize) -> CellState {
+    if !valid_coordinate(x, y) {
+        panic!("Invalid coordinate");
+    }
+    grid[x][y]
+}
+
+fn set_state(grid: &mut Grid, x: usize, y: usize, state: CellState) {
+    if !valid_coordinate(x, y) {
+        panic!("Invalid coordinate");
+    }
+    grid[x][y] = state;
+}
+
+fn set_alive(grid: &mut Grid, x: usize, y: usize) {
+    set_state(grid, x, y, CellState::Alive);
+}
+
+fn set_dead(grid: &mut Grid, x: usize, y: usize) {
+    set_state(grid, x, y, CellState::Dead);
+}
+
+#[macroquad::main(window_conf)]
 async fn main() {
+    let mut grid: Grid = [[CellState::Dead; GRID_WIDTH]; GRID_HEIGHT];
+    set_alive(&mut grid, 4, 4);
+
     loop {
-        clear_background(LIGHTGRAY);
-        draw_text("Conways Game of Life", 20.0, 20.0, 30.0, BLACK);
+        clear_background(DARKGRAY);
+
+        for i in (0..GRID_WIDTH) {
+            for j in (0..GRID_HEIGHT) {
+                let state = get_state(&grid, i, j);
+                let color = if (state == CellState::Alive) {
+                    YELLOW
+                } else {
+                    LIGHTGRAY
+                };
+                draw_rectangle(
+                    (GRID_WIDTH * i) as f32,
+                    (GRID_HEIGHT * j) as f32,
+                    CELL_SIZE,
+                    CELL_SIZE,
+                    color,
+                );
+            }
+        }
         next_frame().await
     }
 }


### PR DESCRIPTION
This PR enables you to watch Conway's Game of Life in a fixed 32x32 grid.

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/819d13ef-ac33-44e0-83d3-25206c1425bb">

**Main changes:**
- Refactor grid related code into `grid.rs`
- Add the logic for Conway's Game of Life.
- Update the grid every X ticks and show the result.
- Add tests to `grid.rs` reflecting the game's logic.

**Possible improvements**:
- `neighbours` function in `grid.rs` perhaps can be refactored

**To test**:
- Clone the branch and run `cargo run`