### PR TITLE
Speed up game, randomize grid, quit with Esc key and other misc. changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+build:
+	cargo build
+run:
+	cargo run
+clean:
+	cargo clean

--- a/README.md
+++ b/README.md
@@ -3,12 +3,16 @@
 This is an implementation of [Conway's Game of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life)
 written in Rust with the [macroquad](https://macroquad.rs) crate.
 
+![image](https://github.com/user-attachments/assets/d1a6def1-0f35-4444-b6fa-617ddb33919c)
+
 ## Running
 
 * Clone the repository `git clone git@github.com:dsocolobsky/conways.git`
-* Run `cargo run`
+* Run `make run`
 
 ## Implemented Features
 
-* Barebones project structure and window display.
 * Conway's Game of Life in a 32x32 grid.
+* Speedup holding Space key
+* Generate a random grid pressing the N key
+* Quit the game pressing the Esc key

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -30,39 +30,30 @@ pub fn cell_is_alive(grid: &Grid, x: usize, y: usize) -> bool {
     }
 }
 
-fn neighbours(grid: &Grid, x: usize, y: usize) -> Vec<Option<CellState>> {
-    let mut vec: Vec<Option<CellState>> = vec![];
-    if x > 0 {
-        vec.push(get_cell_state(&grid, x - 1, y));
-        if y > 0 {
-            vec.push(get_cell_state(&grid, x - 1, y - 1));
-        }
-        if y < 255 {
-            vec.push(get_cell_state(&grid, x - 1, y + 1));
-        }
-    }
-    if x < 255 {
-        vec.push(get_cell_state(&grid, x + 1, y));
-        if y > 0 {
-            vec.push(get_cell_state(&grid, x + 1, y - 1));
-        }
-        if y < 255 {
-            vec.push(get_cell_state(&grid, x + 1, y + 1));
-        }
-    }
-    if y > 0 {
-        vec.push(get_cell_state(&grid, x, y - 1));
-    }
-    if y < 255 {
-        vec.push(get_cell_state(&grid, x, y + 1));
-    }
-    vec
+fn neighbours(grid: &Grid, x: usize, y: usize) -> Vec<CellState> {
+    let offsets: [(isize, isize); 8] = [
+        (0, -1),
+        (0, 1),
+        (1, -1),
+        (1, 0),
+        (1, 1),
+        (-1, -1),
+        (-1, 0),
+        (-1, 1),
+    ];
+    offsets
+        .iter()
+        .filter_map(|(ox, oy)| {
+            let nx = (x as isize + *ox) as usize;
+            let ny = (y as isize + *oy) as usize;
+            get_cell_state(&grid, nx, ny)
+        })
+        .collect()
 }
 
 fn alive_neighbours(grid: &Grid, x: usize, y: usize) -> usize {
     neighbours(grid, x, y)
         .into_iter()
-        .flatten()
         .filter(|state| *state == CellState::Alive)
         .count()
 }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,3 +1,5 @@
+use macroquad::rand;
+
 pub const GRID_WIDTH: usize = 32;
 pub const GRID_HEIGHT: usize = 32;
 pub const CELL_SIZE: f32 = 30.0;
@@ -88,7 +90,7 @@ pub fn next_state_for_grid(grid: &Grid) -> Grid {
     new_grid
 }
 
-pub fn create_initial_grid(alive: Vec<(usize, usize)>) -> Grid {
+pub fn create_grid(alive: Vec<(usize, usize)>) -> Grid {
     let mut new_grid: Grid = [[CellState::Dead; GRID_WIDTH]; GRID_HEIGHT];
     for (i, j) in alive {
         new_grid[i][j] = CellState::Alive;
@@ -96,13 +98,24 @@ pub fn create_initial_grid(alive: Vec<(usize, usize)>) -> Grid {
     new_grid
 }
 
+pub fn create_random_grid() -> Grid {
+    let mut positions: Vec<(usize, usize)> = vec![];
+    let num_alive = rand::gen_range(8, 200);
+    for _ in (0..num_alive) {
+        let row = rand::gen_range(0, GRID_WIDTH);
+        let col = rand::gen_range(0, GRID_HEIGHT);
+        positions.push((row, col));
+    }
+    create_grid(positions)
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::grid::{cell_is_alive, create_initial_grid, next_state_for_grid, CellState};
+    use crate::grid::{cell_is_alive, create_grid, next_state_for_grid, CellState};
 
     #[test]
     fn create_grid() {
-        let grid = create_initial_grid(vec![(5, 5)]);
+        let grid = create_grid(vec![(5, 5)]);
         for (i, &row) in grid.iter().enumerate() {
             for (j, &cell) in row.iter().enumerate() {
                 if i == 5 && j == 5 {
@@ -116,7 +129,7 @@ mod tests {
 
     #[test]
     fn cell_dies_of_underpopulation() {
-        let grid = create_initial_grid(vec![(5, 5)]);
+        let grid = create_grid(vec![(5, 5)]);
         assert!(cell_is_alive(&grid, 5, 5));
         let grid = next_state_for_grid(&grid);
         assert!(!cell_is_alive(&grid, 5, 5));
@@ -124,7 +137,7 @@ mod tests {
 
     #[test]
     fn cell_dies_of_overpopulation() {
-        let grid = create_initial_grid(vec![(5, 5), (5, 6), (5, 4), (4, 5), (6, 6)]);
+        let grid = create_grid(vec![(5, 5), (5, 6), (5, 4), (4, 5), (6, 6)]);
         assert!(cell_is_alive(&grid, 5, 5));
         let grid = next_state_for_grid(&grid);
         assert!(!cell_is_alive(&grid, 5, 5));
@@ -132,7 +145,7 @@ mod tests {
 
     #[test]
     fn cell_survives() {
-        let grid = create_initial_grid(vec![(5, 5), (5, 6), (5, 4)]);
+        let grid = create_grid(vec![(5, 5), (5, 6), (5, 4)]);
         assert!(cell_is_alive(&grid, 5, 5));
         let grid = next_state_for_grid(&grid);
         assert!(cell_is_alive(&grid, 5, 5));
@@ -140,7 +153,7 @@ mod tests {
 
     #[test]
     fn blinker_pattern() {
-        let grid = create_initial_grid(vec![(5, 5), (5, 6), (5, 7)]);
+        let grid = create_grid(vec![(5, 5), (5, 6), (5, 7)]);
         assert!(cell_is_alive(&grid, 5, 5));
         assert!(cell_is_alive(&grid, 5, 6));
         assert!(cell_is_alive(&grid, 5, 7));

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -32,7 +32,7 @@ pub fn cell_is_alive(grid: &Grid, x: usize, y: usize) -> bool {
     }
 }
 
-fn neighbours(grid: &Grid, x: usize, y: usize) -> Vec<CellState> {
+fn neighbour_positions(x: usize, y: usize) -> Vec<(usize, usize)> {
     let offsets: [(isize, isize); 8] = [
         (0, -1),
         (0, 1),
@@ -48,16 +48,21 @@ fn neighbours(grid: &Grid, x: usize, y: usize) -> Vec<CellState> {
         .filter_map(|(ox, oy)| {
             let nx = (x as isize + *ox) as usize;
             let ny = (y as isize + *oy) as usize;
-            get_cell_state(&grid, nx, ny)
+            if valid_coordinate(nx, ny) {
+                Some((nx, ny))
+            } else {
+                None
+            }
         })
         .collect()
 }
 
 fn alive_neighbours(grid: &Grid, x: usize, y: usize) -> usize {
-    neighbours(grid, x, y)
+    let n = neighbour_positions(x, y)
         .into_iter()
-        .filter(|state| *state == CellState::Alive)
-        .count()
+        .filter(|(nx, ny)| cell_is_alive(&grid, *nx, *ny));
+
+    n.count()
 }
 
 fn next_state_for_cell(grid: &Grid, x: usize, y: usize) -> CellState {
@@ -99,22 +104,26 @@ pub fn create_grid(alive: Vec<(usize, usize)>) -> Grid {
 }
 
 pub fn create_random_grid() -> Grid {
-    let mut positions: Vec<(usize, usize)> = vec![];
     let num_alive = rand::gen_range(8, 200);
-    for _ in (0..num_alive) {
-        let row = rand::gen_range(0, GRID_WIDTH);
-        let col = rand::gen_range(0, GRID_HEIGHT);
-        positions.push((row, col));
-    }
+    let positions = (0..num_alive) // Generate #num_alive random positions in grid
+        .map(|_| {
+            (
+                rand::gen_range(0, GRID_WIDTH),
+                rand::gen_range(0, GRID_HEIGHT),
+            )
+        })
+        .collect();
     create_grid(positions)
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::grid::{cell_is_alive, create_grid, next_state_for_grid, CellState};
+    use crate::grid::{
+        alive_neighbours, cell_is_alive, create_grid, next_state_for_grid, CellState,
+    };
 
     #[test]
-    fn create_grid() {
+    fn grid_with_one_cell() {
         let grid = create_grid(vec![(5, 5)]);
         for (i, &row) in grid.iter().enumerate() {
             for (j, &cell) in row.iter().enumerate() {
@@ -125,6 +134,12 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn cell_at_corner() {
+        let grid = create_grid(vec![(0, 0), (0, 1), (1, 0)]);
+        assert_eq!(alive_neighbours(&grid, 0, 0), 2);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn window_conf() -> Conf {
 async fn main() {
     let mut last_update = get_time();
     let mut speed = SLOW_SPEED;
-    let mut grid: Grid = grid::create_initial_grid(vec![
+    let mut grid: Grid = grid::create_grid(vec![
         (5, 5),
         (6, 6),
         (7, 4),
@@ -38,6 +38,10 @@ async fn main() {
             speed = FAST_SPEED;
         } else if is_key_released(KeyCode::Space) {
             speed = SLOW_SPEED;
+        }
+
+        if is_key_pressed(KeyCode::N) {
+            grid = grid::create_random_grid()
         }
 
         if get_time() - last_update > speed {
@@ -64,6 +68,7 @@ async fn main() {
         }
 
         draw_text("Hold SPACE to advance speed", 20.0, 20.0, 30.0, RED);
+        draw_text("Press N to randomize", 500.0, 20.0, 30.0, RED);
         next_frame().await
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,8 @@ async fn main() {
         (14, 12), // Stick
     ]);
 
-    loop {
+    let mut running = true;
+    while running {
         clear_background(DARKGRAY);
 
         if is_key_pressed(KeyCode::Space) {
@@ -42,6 +43,10 @@ async fn main() {
 
         if is_key_pressed(KeyCode::N) {
             grid = grid::create_random_grid()
+        }
+
+        if is_key_pressed(KeyCode::Escape) {
+            running = false;
         }
 
         if get_time() - last_update > speed {
@@ -68,7 +73,8 @@ async fn main() {
         }
 
         draw_text("Hold SPACE to advance speed", 20.0, 20.0, 30.0, RED);
-        draw_text("Press N to randomize", 500.0, 20.0, 30.0, RED);
+        draw_text("Press N to randomize", 430.0, 20.0, 30.0, RED);
+        draw_text("Press ESC to exit", 800.0, 20.0, 30.0, RED);
         next_frame().await
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,9 @@ mod grid;
 use crate::grid::{CellState, Grid};
 use macroquad::prelude::*;
 
+const SLOW_SPEED: f64 = 0.3;
+const FAST_SPEED: f64 = 0.05;
+
 fn window_conf() -> Conf {
     Conf {
         window_title: String::from("Conways"),
@@ -16,7 +19,7 @@ fn window_conf() -> Conf {
 #[macroquad::main(window_conf)]
 async fn main() {
     let mut last_update = get_time();
-    let speed = 0.3;
+    let mut speed = SLOW_SPEED;
     let mut grid: Grid = grid::create_initial_grid(vec![
         (5, 5),
         (6, 6),
@@ -30,6 +33,12 @@ async fn main() {
 
     loop {
         clear_background(DARKGRAY);
+
+        if is_key_pressed(KeyCode::Space) {
+            speed = FAST_SPEED;
+        } else if is_key_released(KeyCode::Space) {
+            speed = SLOW_SPEED;
+        }
 
         if get_time() - last_update > speed {
             last_update = get_time();
@@ -53,6 +62,8 @@ async fn main() {
                 );
             }
         }
+
+        draw_text("Hold SPACE to advance speed", 20.0, 20.0, 30.0, RED);
         next_frame().await
     }
 }


### PR DESCRIPTION
In this PR:

- You can now speedup the game if you hold the Space key
- You can now randomize the grid if you press the N key
- You can now quit the game if you press Esc
- Refactor some functions to be cleaner, mainly `neighbours` and `create_initial_grid`.
- Add a simple Makefile
- Adds a new test to test the edge case with a cell in the corner of the grid
- Change README.md to reflect the changes

![image](https://github.com/user-attachments/assets/d1a6def1-0f35-4444-b6fa-617ddb33919c)