### PR TITLE
Review fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-macroquad = "0.4"
+macroquad = { version = "0.4", features = [] }

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
-build:
-	cargo build
+.PHONY: run
 run:
 	cargo run
+
+.PHONY: build
+build:
+	cargo build
+
+.PHONY: clean
 clean:
 	cargo clean
+
+.PHONY: test
+test:
+	cargo test

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ written in Rust with the [macroquad](https://macroquad.rs) crate.
 
 ## Running
 
-* Clone the repository `git clone git@github.com:dsocolobsky/conways.git`
+* Clone the repository `git clone git@github.com:dsocolobsky/conways.git && cd conways`
 * Run `make run`
 
 ## Implemented Features

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -6,128 +6,144 @@ pub enum CellState {
     Alive,
 }
 
-pub type Grid = Vec<Vec<CellState>>;
-
-fn valid_coordinate(grid: &Grid, row: usize, col: usize) -> bool {
-    let (width, height) = dimensions(grid);
-    row < height && col < width
+pub struct Conways {
+    pub(crate) grid: Vec<Vec<CellState>>,
 }
 
-pub fn get_cell_state(grid: &Grid, x: usize, y: usize) -> CellState {
-    grid.get(x)
-        .and_then(|row| row.get(y))
-        .map_or(CellState::Dead, |s| *s)
-}
+impl Conways {
+    pub(crate) fn new(width: usize, height: usize, alive: Vec<(usize, usize)>) -> Self {
+        let mut conways = Self {
+            grid: vec![vec![CellState::Dead; width]; height],
+        };
+        for (i, j) in alive {
+            conways.grid[i][j] = CellState::Alive;
+        }
+        conways
+    }
 
-pub fn cell_is_alive(grid: &Grid, x: usize, y: usize) -> bool {
-    get_cell_state(grid, x, y) == CellState::Alive
-}
+    fn set_cells_to(&mut self, width: usize, height: usize, alive: Vec<(usize, usize)>) {
+        let mut grid = vec![vec![CellState::Dead; width]; height];
+        for (i, j) in alive {
+            grid[i][j] = CellState::Alive;
+        }
+        self.grid = grid;
+    }
 
-fn neighbour_positions(grid: &Grid, x: usize, y: usize) -> Vec<(usize, usize)> {
-    let offsets: [(isize, isize); 8] = [
-        (0, -1),
-        (0, 1),
-        (1, -1),
-        (1, 0),
-        (1, 1),
-        (-1, -1),
-        (-1, 0),
-        (-1, 1),
-    ];
-    offsets
-        .iter()
-        .filter_map(|(ox, oy)| {
-            let nx = (x as isize + *ox) as usize;
-            let ny = (y as isize + *oy) as usize;
-            if valid_coordinate(grid, nx, ny) {
-                Some((nx, ny))
+    pub fn set_to_random_grid(&mut self, width: usize, height: usize) {
+        let lower_lim = width * height / 30;
+        let upper_lim = width * height / 2;
+        let num_alive = rand::gen_range(lower_lim, upper_lim);
+        let positions =
+            (0..num_alive) // Generate #num_alive random positions in grid
+                .map(|_| (rand::gen_range(0, height), rand::gen_range(0, width)))
+                .collect();
+        self.set_cells_to(width, height, positions);
+    }
+
+    fn valid_coordinate(&self, row: usize, col: usize) -> bool {
+        let (width, height) = self.dimensions();
+        row < height && col < width
+    }
+
+    pub fn get_cell_state(&self, x: usize, y: usize) -> CellState {
+        self.grid
+            .get(x)
+            .and_then(|row| row.get(y))
+            .map_or(CellState::Dead, |s| *s)
+    }
+
+    pub fn cell_is_alive(&self, x: usize, y: usize) -> bool {
+        self.get_cell_state(x, y) == CellState::Alive
+    }
+
+    fn neighbour_positions(&self, x: usize, y: usize) -> Vec<(usize, usize)> {
+        let offsets: [(isize, isize); 8] = [
+            (0, -1),
+            (0, 1),
+            (1, -1),
+            (1, 0),
+            (1, 1),
+            (-1, -1),
+            (-1, 0),
+            (-1, 1),
+        ];
+        offsets
+            .iter()
+            .filter_map(|(ox, oy)| {
+                let nx = (x as isize + *ox) as usize;
+                let ny = (y as isize + *oy) as usize;
+                if self.valid_coordinate(nx, ny) {
+                    Some((nx, ny))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    fn alive_neighbours(&self, x: usize, y: usize) -> usize {
+        let n = self
+            .neighbour_positions(x, y)
+            .into_iter()
+            .filter(|(nx, ny)| self.cell_is_alive(*nx, *ny));
+
+        n.count()
+    }
+
+    fn next_state_for_cell(&self, x: usize, y: usize) -> CellState {
+        let currently_alive = self.cell_is_alive(x, y);
+        let neighbours = self.alive_neighbours(x, y);
+        if currently_alive {
+            if (2..=3).contains(&neighbours) {
+                CellState::Alive
             } else {
-                None
+                CellState::Dead
             }
-        })
-        .collect()
-}
-
-fn alive_neighbours(grid: &Grid, x: usize, y: usize) -> usize {
-    let n = neighbour_positions(grid, x, y)
-        .into_iter()
-        .filter(|(nx, ny)| cell_is_alive(grid, *nx, *ny));
-
-    n.count()
-}
-
-fn next_state_for_cell(grid: &Grid, x: usize, y: usize) -> CellState {
-    let currently_alive = cell_is_alive(grid, x, y);
-    let neighbours = alive_neighbours(grid, x, y);
-    if currently_alive {
-        if (2..=3).contains(&neighbours) {
+        } else if neighbours == 3 {
             CellState::Alive
         } else {
             CellState::Dead
         }
-    } else if neighbours == 3 {
-        CellState::Alive
-    } else {
-        CellState::Dead
     }
-}
 
-pub fn next_state_for_grid(grid: &Grid) -> Grid {
-    let (width, height) = dimensions(grid);
-    let mut new_grid: Grid = vec![vec![CellState::Dead; width]; height];
+    pub fn advance_state(&mut self) {
+        let (width, height) = self.dimensions();
+        let mut new_grid = vec![vec![CellState::Dead; width]; height];
 
-    for (i, row) in grid.iter().enumerate() {
-        for (j, _) in row.iter().enumerate() {
-            new_grid[i][j] = next_state_for_cell(grid, i, j);
+        for (i, row) in self.grid.iter().enumerate() {
+            for (j, _) in row.iter().enumerate() {
+                new_grid[i][j] = self.next_state_for_cell(i, j);
+            }
         }
+
+        self.grid = new_grid;
     }
 
-    new_grid
-}
-
-pub fn create_grid(width: usize, height: usize, alive: Vec<(usize, usize)>) -> Grid {
-    let mut new_grid: Grid = vec![vec![CellState::Dead; width]; height];
-    for (i, j) in alive {
-        new_grid[i][j] = CellState::Alive;
+    pub fn dimensions(&self) -> (usize, usize) {
+        (self.grid[0].len(), self.grid.len())
     }
-    new_grid
-}
-
-pub fn create_random_grid(width: usize, height: usize) -> Grid {
-    let lower_lim = width * height / 30;
-    let upper_lim = width * height / 2;
-    let num_alive = rand::gen_range(lower_lim, upper_lim);
-    let positions = (0..num_alive) // Generate #num_alive random positions in grid
-        .map(|_| (rand::gen_range(0, height), rand::gen_range(0, width)))
-        .collect();
-    create_grid(width, height, positions)
-}
-
-pub fn dimensions(grid: &Grid) -> (usize, usize) {
-    (grid[0].len(), grid.len())
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::grid::{
-        alive_neighbours, cell_is_alive, create_grid, next_state_for_grid, CellState,
-    };
+    use super::*;
 
     #[test]
     fn test_grid_dimensions() {
-        let grid = create_grid(32, 16, vec![]);
-        assert_eq!(grid.len(), 16);
-        assert_eq!(grid[0].len(), 32);
+        let mut game = Conways::new(32, 16, vec![]);
+        assert_eq!((32, 16), game.dimensions());
 
-        let grid = next_state_for_grid(&grid);
-        assert_eq!(grid.len(), 16);
-        assert_eq!(grid[0].len(), 32);
+        game.advance_state();
+        assert_eq!((32, 16), game.dimensions());
+
+        game.set_to_random_grid(42, 42);
+        assert_eq!((42, 42), game.dimensions());
     }
 
     #[test]
     fn grid_with_one_cell() {
-        let grid = create_grid(32, 32, vec![(5, 5)]);
-        for (i, &ref row) in grid.iter().enumerate() {
+        let game = Conways::new(32, 32, vec![(5, 5)]);
+        for (i, &ref row) in game.grid.iter().enumerate() {
             for (j, &cell) in row.iter().enumerate() {
                 if i == 5 && j == 5 {
                     assert_eq!(cell, CellState::Alive)
@@ -140,55 +156,55 @@ mod tests {
 
     #[test]
     fn cell_at_corner() {
-        let grid = create_grid(32, 32, vec![(0, 0), (0, 1), (1, 0)]);
-        assert_eq!(alive_neighbours(&grid, 0, 0), 2);
+        let game = Conways::new(32, 32, vec![(0, 0), (0, 1), (1, 0)]);
+        assert_eq!(game.alive_neighbours(0, 0), 2);
     }
 
     #[test]
     fn cell_dies_of_underpopulation() {
-        let grid = create_grid(32, 32, vec![(5, 5)]);
-        assert!(cell_is_alive(&grid, 5, 5));
-        let grid = next_state_for_grid(&grid);
-        assert!(!cell_is_alive(&grid, 5, 5));
+        let mut game = Conways::new(32, 32, vec![(5, 5)]);
+        assert!(game.cell_is_alive(5, 5));
+        game.advance_state();
+        assert!(!game.cell_is_alive(5, 5));
     }
 
     #[test]
     fn cell_dies_of_overpopulation() {
-        let grid = create_grid(32, 32, vec![(5, 5), (5, 6), (5, 4), (4, 5), (6, 6)]);
-        assert!(cell_is_alive(&grid, 5, 5));
-        let grid = next_state_for_grid(&grid);
-        assert!(!cell_is_alive(&grid, 5, 5));
+        let mut game = Conways::new(32, 32, vec![(5, 5), (5, 6), (5, 4), (4, 5), (6, 6)]);
+        assert!(game.cell_is_alive(5, 5));
+        game.advance_state();
+        assert!(!game.cell_is_alive(5, 5));
     }
 
     #[test]
     fn cell_survives() {
-        let grid = create_grid(32, 32, vec![(5, 5), (5, 6), (5, 4)]);
-        assert!(cell_is_alive(&grid, 5, 5));
-        let grid = next_state_for_grid(&grid);
-        assert!(cell_is_alive(&grid, 5, 5));
+        let mut game = Conways::new(32, 32, vec![(5, 5), (5, 6), (5, 4)]);
+        assert!(game.cell_is_alive(5, 5));
+        game.advance_state();
+        assert!(game.cell_is_alive(5, 5));
     }
 
     #[test]
     fn blinker_pattern() {
-        let grid = create_grid(32, 32, vec![(5, 5), (5, 6), (5, 7)]);
-        assert!(cell_is_alive(&grid, 5, 5));
-        assert!(cell_is_alive(&grid, 5, 6));
-        assert!(cell_is_alive(&grid, 5, 7));
+        let mut game = Conways::new(32, 32, vec![(5, 5), (5, 6), (5, 7)]);
+        assert!(game.cell_is_alive(5, 5));
+        assert!(game.cell_is_alive(5, 6));
+        assert!(game.cell_is_alive(5, 7));
 
-        let grid = next_state_for_grid(&grid);
-        assert!(cell_is_alive(&grid, 4, 6));
-        assert!(cell_is_alive(&grid, 5, 6));
-        assert!(cell_is_alive(&grid, 6, 6));
+        game.advance_state();
+        assert!(game.cell_is_alive(4, 6));
+        assert!(game.cell_is_alive(5, 6));
+        assert!(game.cell_is_alive(6, 6));
 
-        assert!(!cell_is_alive(&grid, 5, 5));
-        assert!(!cell_is_alive(&grid, 5, 7));
+        assert!(!game.cell_is_alive(5, 5));
+        assert!(!game.cell_is_alive(5, 7));
 
-        let grid = next_state_for_grid(&grid);
-        assert!(cell_is_alive(&grid, 5, 5));
-        assert!(cell_is_alive(&grid, 5, 6));
-        assert!(cell_is_alive(&grid, 5, 7));
+        game.advance_state();
+        assert!(game.cell_is_alive(5, 5));
+        assert!(game.cell_is_alive(5, 6));
+        assert!(game.cell_is_alive(5, 7));
 
-        assert!(!cell_is_alive(&grid, 4, 6));
-        assert!(!cell_is_alive(&grid, 6, 6));
+        assert!(!game.cell_is_alive(4, 6));
+        assert!(!game.cell_is_alive(6, 6));
     }
 }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -57,7 +57,7 @@ fn neighbour_positions(x: usize, y: usize) -> Vec<(usize, usize)> {
 fn alive_neighbours(grid: &Grid, x: usize, y: usize) -> usize {
     let n = neighbour_positions(x, y)
         .into_iter()
-        .filter(|(nx, ny)| cell_is_alive(&grid, *nx, *ny));
+        .filter(|(nx, ny)| cell_is_alive(grid, *nx, *ny));
 
     n.count()
 }
@@ -66,17 +66,15 @@ fn next_state_for_cell(grid: &Grid, x: usize, y: usize) -> CellState {
     let currently_alive = cell_is_alive(grid, x, y);
     let neighbours = alive_neighbours(grid, x, y);
     if currently_alive {
-        if neighbours < 2 || neighbours > 3 {
-            CellState::Dead
-        } else {
+        if (2..=3).contains(&neighbours) {
             CellState::Alive
+        } else {
+            CellState::Dead
         }
+    } else if neighbours == 3 {
+        CellState::Alive
     } else {
-        if neighbours == 3 {
-            CellState::Alive
-        } else {
-            CellState::Dead
-        }
+        CellState::Dead
     }
 }
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -18,11 +18,9 @@ fn valid_coordinate(grid: &Grid, row: usize, col: usize) -> bool {
 }
 
 pub fn get_cell_state(grid: &Grid, x: usize, y: usize) -> CellState {
-    if valid_coordinate(grid, x, y) {
-        grid[x][y]
-    } else {
-        CellState::Dead
-    }
+    grid.get(x)
+        .and_then(|row| row.get(y))
+        .map_or(CellState::Dead, |s| *s)
 }
 
 pub fn cell_is_alive(grid: &Grid, x: usize, y: usize) -> bool {

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -17,19 +17,16 @@ fn valid_coordinate(x: usize, y: usize) -> bool {
     x < GRID_WIDTH && y < GRID_HEIGHT
 }
 
-pub fn get_cell_state(grid: &Grid, x: usize, y: usize) -> Option<CellState> {
+pub fn get_cell_state(grid: &Grid, x: usize, y: usize) -> CellState {
     if valid_coordinate(x, y) {
-        Some(grid[x][y])
+        grid[x][y]
     } else {
-        None
+        CellState::Dead
     }
 }
 
 pub fn cell_is_alive(grid: &Grid, x: usize, y: usize) -> bool {
-    match get_cell_state(grid, x, y) {
-        Some(state) => state == CellState::Alive,
-        _ => false,
-    }
+    get_cell_state(grid, x, y) == CellState::Alive
 }
 
 fn neighbour_positions(x: usize, y: usize) -> Vec<(usize, usize)> {

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,9 +1,5 @@
 use macroquad::rand;
 
-pub const GRID_WIDTH: usize = 32;
-pub const GRID_HEIGHT: usize = 32;
-pub const CELL_SIZE: f32 = 30.0;
-
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum CellState {
     Dead,

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,6 +1,6 @@
 use macroquad::rand;
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum CellState {
     Dead,
     Alive,

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -49,7 +49,8 @@ impl Conways {
         self.grid
             .get(x)
             .and_then(|row| row.get(y))
-            .map_or(CellState::Dead, |s| *s)
+            .copied()
+            .unwrap_or(CellState::Dead)
     }
 
     pub fn cell_is_alive(&self, x: usize, y: usize) -> bool {

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -4,9 +4,8 @@ pub const GRID_WIDTH: usize = 32;
 pub const GRID_HEIGHT: usize = 32;
 pub const CELL_SIZE: f32 = 30.0;
 
-#[derive(Copy, Clone, PartialEq, Default, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub enum CellState {
-    #[default]
     Dead,
     Alive,
 }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -11,7 +11,7 @@ pub struct Conways {
 }
 
 impl Conways {
-    pub(crate) fn new(width: usize, height: usize, alive: Vec<(usize, usize)>) -> Self {
+    pub fn new(width: usize, height: usize, alive: Vec<(usize, usize)>) -> Self {
         let mut conways = Self {
             grid: vec![vec![CellState::Dead; width]; height],
         };
@@ -45,7 +45,7 @@ impl Conways {
         row < height && col < width
     }
 
-    pub fn get_cell_state(&self, x: usize, y: usize) -> CellState {
+    fn get_cell_state(&self, x: usize, y: usize) -> CellState {
         self.grid
             .get(x)
             .and_then(|row| row.get(y))
@@ -94,16 +94,11 @@ impl Conways {
     fn next_state_for_cell(&self, x: usize, y: usize) -> CellState {
         let currently_alive = self.cell_is_alive(x, y);
         let neighbours = self.alive_neighbours(x, y);
-        if currently_alive {
-            if (2..=3).contains(&neighbours) {
-                CellState::Alive
-            } else {
-                CellState::Dead
-            }
-        } else if neighbours == 3 {
-            CellState::Alive
-        } else {
-            CellState::Dead
+        match (currently_alive, neighbours) {
+            (true, 2..=3) => CellState::Alive,
+            (true, _) => CellState::Dead,
+            (false, 3) => CellState::Alive,
+            _ => CellState::Dead,
         }
     }
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -13,7 +13,7 @@ pub enum CellState {
 pub type Grid = Vec<Vec<CellState>>;
 
 fn valid_coordinate(grid: &Grid, row: usize, col: usize) -> bool {
-    let (height, width) = (grid.len(), grid[0].len());
+    let (width, height) = dimensions(grid);
     row < height && col < width
 }
 
@@ -79,7 +79,7 @@ fn next_state_for_cell(grid: &Grid, x: usize, y: usize) -> CellState {
 }
 
 pub fn next_state_for_grid(grid: &Grid) -> Grid {
-    let (height, width) = (grid.len(), grid[0].len());
+    let (width, height) = dimensions(grid);
     let mut new_grid: Grid = vec![vec![CellState::Dead; width]; height];
 
     for (i, row) in grid.iter().enumerate() {
@@ -100,11 +100,17 @@ pub fn create_grid(width: usize, height: usize, alive: Vec<(usize, usize)>) -> G
 }
 
 pub fn create_random_grid(width: usize, height: usize) -> Grid {
-    let num_alive = rand::gen_range(8, 200);
+    let lower_lim = width * height / 30;
+    let upper_lim = width * height / 2;
+    let num_alive = rand::gen_range(lower_lim, upper_lim);
     let positions = (0..num_alive) // Generate #num_alive random positions in grid
         .map(|_| (rand::gen_range(0, height), rand::gen_range(0, width)))
         .collect();
     create_grid(width, height, positions)
+}
+
+pub fn dimensions(grid: &Grid) -> (usize, usize) {
+    (grid[0].len(), grid.len())
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,22 @@
 mod grid;
 
-use crate::grid::{cell_is_alive, Grid};
+use crate::grid::{cell_is_alive, dimensions, Grid};
 use macroquad::prelude::*;
 
 const SLOW_SPEED: f64 = 0.3;
 const FAST_SPEED: f64 = 0.05;
 
 const DEFAULT_GRID_WIDTH: usize = 32;
-const DEFAULT_GRID_HEIGHT: usize = 64;
+const DEFAULT_GRID_HEIGHT: usize = 32;
+
+const SCREEN_WIDTH: i32 = 1024;
+const SCREEN_HEIGHT: i32 = 1024;
 
 fn window_conf() -> Conf {
     Conf {
         window_title: String::from("Conways"),
-        window_width: 1024,
-        window_height: 1024,
+        window_width: SCREEN_WIDTH,
+        window_height: SCREEN_HEIGHT,
         fullscreen: false,
         ..Default::default()
     }
@@ -46,9 +49,7 @@ async fn main() {
         } else if is_key_released(KeyCode::Space) {
             speed = SLOW_SPEED;
         }
-        if is_key_pressed(KeyCode::N) {
-            grid = grid::create_random_grid(DEFAULT_GRID_WIDTH, DEFAULT_GRID_HEIGHT)
-        }
+
         if is_key_pressed(KeyCode::Escape) {
             running = false;
         }
@@ -59,8 +60,18 @@ async fn main() {
         }
         last_update = get_time();
 
+        let (grid_height, grid_width) = dimensions(&grid);
+        if is_key_pressed(KeyCode::N) {
+            grid = grid::create_random_grid((grid_width - 1).max(6), (grid_height - 1).max(6))
+        } else if is_key_pressed(KeyCode::M) {
+            grid = grid::create_random_grid(grid_width + 1, grid_height + 1)
+        }
+
         grid = grid::next_state_for_grid(&grid);
         clear_background(DARKGRAY);
+        let cell_width = SCREEN_WIDTH as f32 / grid_width as f32;
+        let cell_height = SCREEN_HEIGHT as f32 / grid_height as f32;
+        let cell_size = cell_width.min(cell_height);
         for (i, row) in grid.iter().enumerate() {
             for (j, _) in row.iter().enumerate() {
                 let color = if cell_is_alive(&grid, i, j) {
@@ -69,17 +80,17 @@ async fn main() {
                     LIGHTGRAY
                 };
                 draw_rectangle(
-                    (grid::GRID_WIDTH * i) as f32,
-                    (grid::GRID_HEIGHT * j) as f32,
-                    grid::CELL_SIZE,
-                    grid::CELL_SIZE,
+                    (cell_width * i as f32) as f32,
+                    (cell_width * j as f32) as f32,
+                    cell_width,
+                    cell_width,
                     color,
                 );
             }
         }
 
         draw_text("Hold SPACE to advance speed", 20.0, 20.0, 30.0, RED);
-        draw_text("Press N to randomize", 430.0, 20.0, 30.0, RED);
+        draw_text("Press N/M to randomize", 430.0, 20.0, 30.0, RED);
         draw_text("Press ESC to exit", 800.0, 20.0, 30.0, RED);
         next_frame().await
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod grid;
 
-use crate::grid::{CellState, Grid};
+use crate::grid::{cell_is_alive, Grid};
 use macroquad::prelude::*;
 
 const SLOW_SPEED: f64 = 0.3;
@@ -56,8 +56,7 @@ async fn main() {
 
         for (i, row) in grid.iter().enumerate() {
             for (j, _) in row.iter().enumerate() {
-                let state = grid::get_cell_state(&grid, i, j).unwrap_or_default();
-                let color = if state == CellState::Alive {
+                let color = if cell_is_alive(&grid, i, j) {
                     YELLOW
                 } else {
                     LIGHTGRAY

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,8 @@ async fn main() {
     let mut last_update = get_time();
     let mut speed = SLOW_SPEED;
     let mut grid: Grid = grid::create_grid(
-        32,
-        32,
+        DEFAULT_GRID_WIDTH,
+        DEFAULT_GRID_HEIGHT,
         vec![
             (5, 5),
             (6, 6),
@@ -80,10 +80,10 @@ async fn main() {
                     LIGHTGRAY
                 };
                 draw_rectangle(
-                    (cell_width * i as f32) as f32,
-                    (cell_width * j as f32) as f32,
-                    cell_width,
-                    cell_width,
+                    cell_width * i as f32,
+                    cell_width * j as f32,
+                    cell_size,
+                    cell_size,
                     color,
                 );
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod grid;
 
-use crate::grid::{cell_is_alive, dimensions, Grid};
+use crate::grid::Conways;
 use macroquad::prelude::*;
 
 const SLOW_SPEED: f64 = 0.3;
@@ -26,7 +26,7 @@ fn window_conf() -> Conf {
 async fn main() {
     let mut last_update = get_time();
     let mut speed = SLOW_SPEED;
-    let mut grid: Grid = grid::create_grid(
+    let mut game = Conways::new(
         DEFAULT_GRID_WIDTH,
         DEFAULT_GRID_HEIGHT,
         vec![
@@ -60,21 +60,21 @@ async fn main() {
         }
         last_update = get_time();
 
-        let (grid_height, grid_width) = dimensions(&grid);
+        let (grid_height, grid_width) = game.dimensions();
         if is_key_pressed(KeyCode::N) {
-            grid = grid::create_random_grid((grid_width - 1).max(6), (grid_height - 1).max(6))
+            game.set_to_random_grid((grid_width - 1).max(6), (grid_height - 1).max(6))
         } else if is_key_pressed(KeyCode::M) {
-            grid = grid::create_random_grid(grid_width + 1, grid_height + 1)
+            game.set_to_random_grid(grid_width + 1, grid_height + 1)
         }
 
-        grid = grid::next_state_for_grid(&grid);
+        game.advance_state();
         clear_background(DARKGRAY);
         let cell_width = SCREEN_WIDTH as f32 / grid_width as f32;
         let cell_height = SCREEN_HEIGHT as f32 / grid_height as f32;
         let cell_size = cell_width.min(cell_height);
-        for (i, row) in grid.iter().enumerate() {
+        for (i, row) in game.grid.iter().enumerate() {
             for (j, _) in row.iter().enumerate() {
-                let color = if cell_is_alive(&grid, i, j) {
+                let color = if game.cell_is_alive(i, j) {
                     YELLOW
                 } else {
                     LIGHTGRAY

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,9 @@ use macroquad::prelude::*;
 const SLOW_SPEED: f64 = 0.3;
 const FAST_SPEED: f64 = 0.05;
 
+const DEFAULT_GRID_WIDTH: usize = 32;
+const DEFAULT_GRID_HEIGHT: usize = 64;
+
 fn window_conf() -> Conf {
     Conf {
         window_title: String::from("Conways"),
@@ -20,16 +23,20 @@ fn window_conf() -> Conf {
 async fn main() {
     let mut last_update = get_time();
     let mut speed = SLOW_SPEED;
-    let mut grid: Grid = grid::create_grid(vec![
-        (5, 5),
-        (6, 6),
-        (7, 4),
-        (7, 5),
-        (7, 6), // Glider
-        (12, 12),
-        (13, 12),
-        (14, 12), // Stick
-    ]);
+    let mut grid: Grid = grid::create_grid(
+        32,
+        32,
+        vec![
+            (5, 5),
+            (6, 6),
+            (7, 4),
+            (7, 5),
+            (7, 6), // Glider
+            (12, 12),
+            (13, 12),
+            (14, 12), // Stick
+        ],
+    );
 
     let mut running = true;
     while running {
@@ -40,7 +47,7 @@ async fn main() {
             speed = SLOW_SPEED;
         }
         if is_key_pressed(KeyCode::N) {
-            grid = grid::create_random_grid()
+            grid = grid::create_random_grid(DEFAULT_GRID_WIDTH, DEFAULT_GRID_HEIGHT)
         }
         if is_key_pressed(KeyCode::Escape) {
             running = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,27 +33,27 @@ async fn main() {
 
     let mut running = true;
     while running {
-        clear_background(DARKGRAY);
-
+        // Handle Input
         if is_key_pressed(KeyCode::Space) {
             speed = FAST_SPEED;
         } else if is_key_released(KeyCode::Space) {
             speed = SLOW_SPEED;
         }
-
         if is_key_pressed(KeyCode::N) {
             grid = grid::create_random_grid()
         }
-
         if is_key_pressed(KeyCode::Escape) {
             running = false;
         }
 
-        if get_time() - last_update > speed {
-            last_update = get_time();
-            grid = grid::next_state_for_grid(&grid);
+        // Check if we should redraw/recalculate grid
+        if get_time() - last_update < speed {
+            continue;
         }
+        last_update = get_time();
 
+        grid = grid::next_state_for_grid(&grid);
+        clear_background(DARKGRAY);
         for (i, row) in grid.iter().enumerate() {
             for (j, _) in row.iter().enumerate() {
                 let color = if cell_is_alive(&grid, i, j) {


### PR DESCRIPTION
- Make size of grid variable with N/M keys
- Added PHONY targets to Makefile
- Changed README.md
- Made `get_cell_state` to return `CellState` directly instead of `Option<CellState>`. Simplifying the code.
- Use `get/and_then/map_or` in `get_cell_state`.
- Avoid re-drawing in main loop when not necessary.
- Explicitly declare features for `macroquad` crate in our `Cargo.toml` file.
- Fix all Clippy warnings